### PR TITLE
Asynchronous board saving & loading, auto-saving, and board locking

### DIFF
--- a/src/client/CanvasState.lua
+++ b/src/client/CanvasState.lua
@@ -186,6 +186,8 @@ function CanvasState.ConnectWorldBoardSync()
 end
 
 function CanvasState.OpenBoard(board)
+	
+	if not board.HasLoaded.Value then return end
 
 	-- We do not open the BoardGui if we are in VR
 	if VRService.VREnabled then return end

--- a/src/common/Config.lua
+++ b/src/common/Config.lua
@@ -36,6 +36,8 @@ local Config = {
 	WorldLineType = "Parts",
 
 	UseCache = false,
+	
+	AutoSaveInterval = 30, -- Interval in seconds between board persistence saves
 }
 
 Config.Defaults = {
@@ -49,7 +51,7 @@ Config.Defaults = {
 Config.WorldLine = {
 	ZThicknessStuds = 0.01,
 	StudsPerZIndex = 0.001,
-	RoundThresholdStuds = 0.05
+	RoundThresholdStuds = 0.05,
 }
 
 Config.PersonalBoard = {

--- a/src/server/MetaBoard.lua
+++ b/src/server/MetaBoard.lua
@@ -1,4 +1,5 @@
 local CollectionService = game:GetService("CollectionService")
+local HttpService = game:GetService("HttpService")
 local Common = game:GetService("ReplicatedStorage").MetaBoardCommon
 local Config = require(Common.Config)
 local LineInfo = require(Common.LineInfo)
@@ -66,11 +67,19 @@ function MetaBoard.Init()
 			MetaBoard.DrawingTasksTable[player][subscriber] = drawingTask
 			drawingTask.Init(drawingTask.State, ...)
 		end
+		
+		if board.HasLoaded.Value then
+			board.ChangeUid.Value = HttpService:GenerateGUID(false)
+		end
 	end)
 
 	DrawingTask.UpdateRemoteEvent.OnServerEvent:Connect(function(player, ...)
 		for board, drawingTask in pairs(MetaBoard.DrawingTasksTable[player]) do
 			drawingTask.Update(drawingTask.State, ...)
+			
+			if board.HasLoaded.Value then
+				board.ChangeUid.Value = HttpService:GenerateGUID(false)
+			end
 		end
 	end)
 
@@ -203,6 +212,24 @@ function MetaBoard.InitBoard(board)
 		subscribers.Name = "Subscribers"
 		subscribers.Parent = board
 	end
+	
+	local changeUid = board:FindFirstChild("ChangeUid")
+	if changeUid ~= nil then
+		changeUid:Destroy()
+	end
+	changeUid = Instance.new("StringValue")
+	changeUid.Value = ""
+	changeUid.Name = "ChangeUid"
+	changeUid.Parent = board
+	
+	local hasLoaded = board:FindFirstChild("HasLoaded")
+	if hasLoaded ~= nil then
+		hasLoaded:Destroy()
+	end
+	hasLoaded = Instance.new("BoolValue")
+	hasLoaded.Value = false
+	hasLoaded.Name = "HasLoaded"
+	hasLoaded.Parent = board
 end
 
 function MetaBoard.Subscribe(subscriber, broadcaster)
@@ -262,7 +289,7 @@ function MetaBoard.UpdateWorldLine(worldLineType, line, canvas, lineInfo, zIndex
 
 	if worldLineType == "RoundedParts" then
 		line.Color = lineInfo.Color
-		
+
 		if lineInfo.ThicknessYScale * yStuds >= Config.WorldLine.RoundThresholdStuds then
 			line.Size =
 				Vector3.new(
@@ -285,38 +312,38 @@ function MetaBoard.UpdateWorldLine(worldLineType, line, canvas, lineInfo, zIndex
 				canvas.Size.Z/2 - lineInfo.ThicknessYScale * Config.WorldLine.ZThicknessStuds / 2 - zIndex * Config.WorldLine.StudsPerZIndex) *
 			CFrame.Angles(0,0,lineInfo.RotationRadians)
 
-			if lineInfo.ThicknessYScale * yStuds >= Config.WorldLine.RoundThresholdStuds then
-				line.StartCylinder.Color = lineInfo.Color
-		
-				line.StartCylinder.Size =
-					Vector3.new(
-						Config.WorldLine.ZThicknessStuds,
-						lineInfo.ThicknessYScale * yStuds,
-						lineInfo.ThicknessYScale * yStuds)
-		
-				line.StartCylinder.CFrame =
-					canvas.CFrame *
-					CFrame.new(
-						lerp(canvas.Size.X/2,-canvas.Size.X/2,lineInfo.Start.X/aspectRatio), 
-						lerp(canvas.Size.Y/2,-canvas.Size.Y/2,lineInfo.Start.Y),
-						canvas.Size.Z/2 - lineInfo.ThicknessYScale * Config.WorldLine.ZThicknessStuds / 2 - zIndex * Config.WorldLine.StudsPerZIndex) *
-						CFrame.Angles(0,math.pi/2,0)
-		
-				line.StopCylinder.Color = lineInfo.Color
-		
-				line.StopCylinder.Size =
-					Vector3.new(
-						Config.WorldLine.ZThicknessStuds,
-						lineInfo.ThicknessYScale * yStuds,
-						lineInfo.ThicknessYScale * yStuds)
-		
-				line.StopCylinder.CFrame =
-					canvas.CFrame *
-					CFrame.new(
-						lerp(canvas.Size.X/2,-canvas.Size.X/2,lineInfo.Stop.X/aspectRatio), 
-						lerp(canvas.Size.Y/2,-canvas.Size.Y/2,lineInfo.Stop.Y),
-						canvas.Size.Z/2 - lineInfo.ThicknessYScale * Config.WorldLine.ZThicknessStuds / 2 - zIndex * Config.WorldLine.StudsPerZIndex) *
-						CFrame.Angles(0,math.pi/2,0)
+		if lineInfo.ThicknessYScale * yStuds >= Config.WorldLine.RoundThresholdStuds then
+			line.StartCylinder.Color = lineInfo.Color
+
+			line.StartCylinder.Size =
+				Vector3.new(
+					Config.WorldLine.ZThicknessStuds,
+					lineInfo.ThicknessYScale * yStuds,
+					lineInfo.ThicknessYScale * yStuds)
+
+			line.StartCylinder.CFrame =
+				canvas.CFrame *
+				CFrame.new(
+					lerp(canvas.Size.X/2,-canvas.Size.X/2,lineInfo.Start.X/aspectRatio), 
+					lerp(canvas.Size.Y/2,-canvas.Size.Y/2,lineInfo.Start.Y),
+					canvas.Size.Z/2 - lineInfo.ThicknessYScale * Config.WorldLine.ZThicknessStuds / 2 - zIndex * Config.WorldLine.StudsPerZIndex) *
+				CFrame.Angles(0,math.pi/2,0)
+
+			line.StopCylinder.Color = lineInfo.Color
+
+			line.StopCylinder.Size =
+				Vector3.new(
+					Config.WorldLine.ZThicknessStuds,
+					lineInfo.ThicknessYScale * yStuds,
+					lineInfo.ThicknessYScale * yStuds)
+
+			line.StopCylinder.CFrame =
+				canvas.CFrame *
+				CFrame.new(
+					lerp(canvas.Size.X/2,-canvas.Size.X/2,lineInfo.Stop.X/aspectRatio), 
+					lerp(canvas.Size.Y/2,-canvas.Size.Y/2,lineInfo.Stop.Y),
+					canvas.Size.Z/2 - lineInfo.ThicknessYScale * Config.WorldLine.ZThicknessStuds / 2 - zIndex * Config.WorldLine.StudsPerZIndex) *
+				CFrame.Angles(0,math.pi/2,0)
 		end
 	end
 
@@ -392,11 +419,11 @@ function MetaBoard.CreateWorldLine(worldLineType, canvas, lineInfo, zIndex)
 			local startCylinder = newSmoothNonPhysicalPart()
 			startCylinder.Shape = Enum.PartType.Cylinder
 			startCylinder.Name = "StartCylinder"
-			
+
 			local stopCylinder = newSmoothNonPhysicalPart()
 			stopCylinder.Shape = Enum.PartType.Cylinder
 			stopCylinder.Name = "StopCylinder"
-			
+
 			startCylinder.Parent = line
 			stopCylinder.Parent = line
 		end

--- a/src/server/Persistence.lua
+++ b/src/server/Persistence.lua
@@ -243,7 +243,6 @@ function Persistence.Store(board, boardKey)
 	if board.ChangeUid.Value == "" then
 		return
 	end
-	print("A")
 	
     local DataStore = DataStoreService:GetDataStore(Config.DataStoreTag)
 

--- a/src/server/Persistence.lua
+++ b/src/server/Persistence.lua
@@ -54,7 +54,7 @@ function Persistence.Init()
         for _, board in ipairs(boardsClose) do
             local persistId = board:FindFirstChild("PersistId")
             if persistId and persistId:IsA("IntValue") then
-                Persistence.Store(board, keyForBoard(board))
+                task.spawn(Persistence.Store, board, keyForBoard(board))
             end
         end
     end)


### PR DESCRIPTION
Dan's issue https://github.com/metauni/metaboard/issues/20 brought up that boards were saving upon game shutdown synchronously, so they were changed to save asynchronously instead. There is still a relationship between more boards and longer save times (I was getting shutdown times of about 10 seconds with 27 boards). Boards won't save anymore unless a change was made to them, since otherwise there are unnecessary requests to save being made. This should also cut down on save time.

Boards now load asynchronously too which is very noticeable, and are locked for editing until they've successfuly loaded.