### PR TITLE
Per-board default colours and colour state

### DIFF
--- a/src/client/Buttons.lua
+++ b/src/client/Buttons.lua
@@ -244,7 +244,7 @@ function Buttons.ConnectColorButton(colorButton)
 			ShadeFrame:SetAttribute("ColorButton", colorButton.Name)
 		end
 
-		Drawing.EquippedTool:SetColor(colorButton.BackgroundColor3)
+		Drawing.SetEquippedToolColor(colorButton.BackgroundColor3)
 		Buttons.SyncPenButton(Drawing.EquippedTool.GuiButton, Drawing.EquippedTool)
 
 		-- Unhighlight all erasers
@@ -594,7 +594,7 @@ function Buttons.ConnectSelectShadeButton(button, shadeFrame)
 	
 	local function SetShade(colorName, newColor)
 		Drawing.EquippedTool.AllColors[colorName] = newColor
-		Drawing.EquippedTool:SetColor(newColor)
+		Drawing.SetEquippedToolColor(newColor)
 		Toolbar.Colors[colorName].BackgroundColor3 = newColor
 		Buttons.SyncPenButton(Drawing.EquippedTool.GuiButton, Drawing.EquippedTool)	
 	end


### PR DESCRIPTION
* Implements https://github.com/metauni/metaboard/issues/42
* Answers **no** to "should the entire state of your drawing tools be stored per-board instead of globally rather than just the pen colours?"